### PR TITLE
Minor typo fix in CmakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
   endif()
 
 if(NOT DEFINED CUB_DIR AND DEFINED ENV{CUB_DIR})
-  set(CUB_DIR ENV{CUB_DIR})
+  set(CUB_DIR $ENV{CUB_DIR})
 endif()
 
 message(STATUS "Finding CUB")


### PR DESCRIPTION
No $ symbol to get CUB_DIR from environment variables
The  CUB_DIR environment variables no use for building the lib